### PR TITLE
Fixed star with border misaligned vertically

### DIFF
--- a/src/star-rating.vue
+++ b/src/star-rating.vue
@@ -195,7 +195,6 @@ export default {
 }
 
 .vue-star-rating-rating-text {
-    margin-top: 7px;
     margin-left: 7px;
 }
 

--- a/src/star.vue
+++ b/src/star.vue
@@ -143,8 +143,9 @@ export default {
             return Math.random().toString(36).substring(7)
         },
         calculatePoints() {
-            this.starPoints = this.starPoints.map((point) => {
-                return ((this.size / this.maxSize) * point) + (this.border * 1.5)
+            this.starPoints = this.starPoints.map((point, i) => {
+                const offset = i % 2 === 0 ? this.border * 1.5 : 0
+                return ((this.size / this.maxSize) * point) + offset
             })
         }
     },


### PR DESCRIPTION
Seems to be stars with border-width are misaligned downwardly a little bit. This is more obvious with small-sized stars. Made small sample here.
https://jsfiddle.net/7c1dpxr6/3/

This patch is to modify the logic around calculating offset on points in order not to add offset if it's point for y-axis, so that stars are vertically aligned in center.
Removed margin-top from `.vue-star-rating-rating-text` as I suppose it's not necessary any more.